### PR TITLE
Retry deployment after 10 seconds 3 Times

### DIFF
--- a/.github/workflows/build-public-inbox.yml
+++ b/.github/workflows/build-public-inbox.yml
@@ -47,6 +47,14 @@ jobs:
         run: npm i -g @railway/cli
 
       - name: Deploy
-        run: railway up --service public-inbox
+        run: | # This script retries the deployment 3 times before failing because railway sometimes fails to deploy
+          n=0
+          until [ "$n" -ge 3 ]
+          do
+            railway up --service public-inbox && break
+            n=$((n+1))
+            echo "Retrying deployment... attempt $n"
+            sleep 10
+          done
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+            RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
From my research, the error mainly happens with Railway (sometimes the authentication skips), and then it fails. I’m adding a retry mechanism that will try 3 times. I believe it will work because when I manually restart the workflow, it usually passes the second time. If this doesn’t work, we can easily undo this change.

cc @satsie , @jrakibi
