### PR TITLE
ci: add failure detection for Railway deployment retries

### DIFF
--- a/.github/workflows/build-public-inbox.yml
+++ b/.github/workflows/build-public-inbox.yml
@@ -56,5 +56,11 @@ jobs:
             echo "Retrying deployment... attempt $n"
             sleep 10
           done
+          
+          # Check if all retries failed
+          if [ "$n" -eq 3 ]; then
+            echo "All deployment attempts failed"
+            exit 1 
+          fi
         env:
-            RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
Currently, if all Railway deployment attempts fail, the job still reports success because the last executed command (`sleep` or `echo`) returns a success status. This makes it difficult to automatically detect deployment failures.

This PR adds explicit failure detection.

Before this change, failures could only be detected by manually reviewing the logs for "Retrying deployment" messages.